### PR TITLE
busybox: don't use update-alternatives for sh

### DIFF
--- a/meta/recipes-core/busybox/busybox.inc
+++ b/meta/recipes-core/busybox/busybox.inc
@@ -338,10 +338,11 @@ python do_package_prepend () {
             # Match coreutils
             if alt_name == '[':
                 alt_name = 'lbracket'
-            d.appendVar('ALTERNATIVE_%s' % (pn), ' ' + alt_name)
-            d.setVarFlag('ALTERNATIVE_LINK_NAME', alt_name, alt_link_name)
-            if os.path.exists('%s%s' % (dvar, target)):
-                d.setVarFlag('ALTERNATIVE_TARGET', alt_name, target)
+            if alt_name != 'sh':
+                d.appendVar('ALTERNATIVE_%s' % (pn), ' ' + alt_name)
+                d.setVarFlag('ALTERNATIVE_LINK_NAME', alt_name, alt_link_name)
+                if os.path.exists('%s%s' % (dvar, target)):
+                    d.setVarFlag('ALTERNATIVE_TARGET', alt_name, target)
         f.close()
         return
 


### PR DESCRIPTION
This fix busybox package update.
It looks like the trick with sh copying in tmp does not work.
update-alternatives is bash script that link to /bin/sh. When run script prerm on package update update-alternatives removes /bin/sh, and after it stops working. It breaks the package installation.

In the package already is link to sh, why is necessary use update-alternatives for it?
So when sh is removed from update-alternatives list, it's not deleted on package update, and update works as I expect.
